### PR TITLE
Separate build from run on Make functor for Ox controller.

### DIFF
--- a/lib/OxStart.ml
+++ b/lib/OxStart.ml
@@ -99,10 +99,11 @@ module Make (Handlers:OXMODULE) = struct
             (Exn.to_string exn);
           exit 1)
 
-  let _ =
+  let run () : unit =
     let open Core.Std in
     (* intentionally on stdout *)
     Format.printf "Ox controller launching...\n%!";
     Sys.catch_break true;
-    never_returns (Scheduler.go_main start_controller ());
+    never_returns (Scheduler.go_main start_controller ())
+
 end

--- a/lib/OxStart.mli
+++ b/lib/OxStart.mli
@@ -45,13 +45,20 @@ module type OXMODULE = sig
   controller loop. *)
   val cleanup : unit -> unit
 
-
 end
 
-(** Given an [OXMODULE] module, build and run (!) an Ox controller
+(** Given an [OXMODULE] module, build an Ox controller
     that, listens on port 6633 for messages from OpenFlow-enabled
     switches.  Messages and network events are passed to the
     appropriate [OXMODULE] callbacks. *)
 module Make : functor (OxModule:OXMODULE) -> sig
+
+   (** [start_controller] is called to start the Ox controller, and return
+    execution to the calling thread. *)     
+   val start_controller : unit -> unit               
+
+   (** [run] is called to start the Ox controller. Note that execution
+    will not be transfered back to the calling thread. *)
+   val run : unit -> unit                          
 
 end


### PR DESCRIPTION
Exposed start_controller and run functions to separate building the module from running the module.